### PR TITLE
chore: move steps into scripts/, scheduler -> main.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ database server, no extra services.
 
 ## Pipeline
 
-Four independent steps, each runnable on its own, plus a scheduler that
-chains them together.
+Four independent step scripts live in `scripts/`, each runnable on its
+own. `main.py` at the project root chains them together.
 
-| Script          | What it does                                                                 |
-| --------------- | ---------------------------------------------------------------------------- |
-| `fetch.py`      | Pull `N` new repositories from GitHub Search and insert them into the DB.    |
-| `evaluate.py`   | Clone unrated repos, ask Ollama for `idea`, `skill`, `description`, store.   |
-| `subscribe.py`  | Follow profiles whose repos updated in the last `W` hours scored above `X`.  |
-| `star.py`       | Star repos updated in the last `W` hours that scored above `Y`.              |
-| `scheduler.py`  | Runs `fetch -> evaluate -> subscribe -> star` once, or in an infinite loop.  |
+| Script                  | What it does                                                                 |
+| ----------------------- | ---------------------------------------------------------------------------- |
+| `scripts/fetch.py`      | Pull `N` new repositories from GitHub Search and insert them into the DB.    |
+| `scripts/evaluate.py`   | Clone unrated repos, ask Ollama for `idea`, `skill`, `description`, store.   |
+| `scripts/subscribe.py`  | Follow profiles whose repos updated in the last `W` hours scored above `X`.  |
+| `scripts/star.py`       | Star repos updated in the last `W` hours that scored above `Y`.              |
+| `main.py`               | Runs `fetch -> evaluate -> subscribe -> star` once, or in an infinite loop.  |
 
 ## Schema
 
@@ -65,37 +65,37 @@ Every script reads `.env` from the project root. Flags override env values.
 ### Fetch new repositories
 
 ```bash
-python3 fetch.py -n 5
+python3 scripts/fetch.py -n 5
 ```
 
 ### Evaluate everything not yet rated
 
 ```bash
-python3 evaluate.py            # rate all pending
-python3 evaluate.py -l 10      # rate up to 10
+python3 scripts/evaluate.py            # rate all pending
+python3 scripts/evaluate.py -l 10      # rate up to 10
 ```
 
 ### Follow high-scoring authors (recent window)
 
 ```bash
-python3 subscribe.py -s 14 -w 24
-python3 subscribe.py --dry-run
+python3 scripts/subscribe.py -s 14 -w 24
+python3 scripts/subscribe.py --dry-run
 ```
 
 ### Star high-scoring repos (recent window)
 
 ```bash
-python3 star.py -s 16 -w 24
-python3 star.py --dry-run
+python3 scripts/star.py -s 16 -w 24
+python3 scripts/star.py --dry-run
 ```
 
 ### Run the full cycle
 
 ```bash
-python3 scheduler.py                            # one cycle, defaults from .env
-python3 scheduler.py -n 5 --subscribe-threshold 14 --star-threshold 16 -w 24
-python3 scheduler.py --dry-run                  # safe rehearsal
-python3 scheduler.py -i --sleep 600             # loop forever
+python3 main.py                            # one cycle, defaults from .env
+python3 main.py -n 5 --subscribe-threshold 14 --star-threshold 16 -w 24
+python3 main.py --dry-run                  # safe rehearsal
+python3 main.py -i --sleep 600             # loop forever
 ```
 
 The default cycle is exactly what the project was built around:

--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )
-logger = logging.getLogger("scheduler")
+logger = logging.getLogger("main")
 
 
 def parse_args() -> argparse.Namespace:
@@ -54,10 +54,10 @@ def step(label: str) -> None:
 
 
 def run_cycle(args: argparse.Namespace, settings: dict) -> None:
-    from fetch import main as fetch_main
-    from evaluate import main as evaluate_main
-    from subscribe import main as subscribe_main
-    from star import main as star_main
+    from scripts.fetch import main as fetch_main
+    from scripts.evaluate import main as evaluate_main
+    from scripts.subscribe import main as subscribe_main
+    from scripts.star import main as star_main
 
     count = args.count if args.count is not None else settings["fetch_count"]
     subscribe_threshold = args.subscribe_threshold if args.subscribe_threshold is not None else settings["subscribe_threshold"]
@@ -65,22 +65,22 @@ def run_cycle(args: argparse.Namespace, settings: dict) -> None:
     window = args.window_hours if args.window_hours is not None else settings["window_hours"]
 
     step(f"fetch -n {count}")
-    sys.argv = ["fetch.py", "-n", str(count)]
+    sys.argv = ["scripts/fetch.py", "-n", str(count)]
     fetch_main()
 
     step(f"evaluate{'' if args.evaluate_limit is None else f' -l {args.evaluate_limit}'}")
-    sys.argv = ["evaluate.py"] + (["-l", str(args.evaluate_limit)] if args.evaluate_limit is not None else [])
+    sys.argv = ["scripts/evaluate.py"] + (["-l", str(args.evaluate_limit)] if args.evaluate_limit is not None else [])
     evaluate_main()
 
     step(f"subscribe -s {subscribe_threshold} -w {window}")
-    sub_argv = ["subscribe.py", "-s", str(subscribe_threshold), "-w", str(window)]
+    sub_argv = ["scripts/subscribe.py", "-s", str(subscribe_threshold), "-w", str(window)]
     if args.dry_run:
         sub_argv.append("--dry-run")
     sys.argv = sub_argv
     subscribe_main()
 
     step(f"star -s {star_threshold} -w {window}")
-    star_argv = ["star.py", "-s", str(star_threshold), "-w", str(window)]
+    star_argv = ["scripts/star.py", "-s", str(star_threshold), "-w", str(window)]
     if args.dry_run:
         star_argv.append("--dry-run")
     sys.argv = star_argv

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -10,6 +10,11 @@ import sys
 import traceback
 from pathlib import Path
 
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 from libs import db, digest, ollama
 from libs.settings import load_settings
 
@@ -30,7 +35,7 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    settings = load_settings(Path(__file__).resolve().parent)
+    settings = load_settings(PROJECT_ROOT)
     conn = db.connect(settings["db_path"])
 
     pending = db.unevaluated(conn, limit=args.limit)

--- a/scripts/fetch.py
+++ b/scripts/fetch.py
@@ -8,6 +8,11 @@ import logging
 import sys
 from pathlib import Path
 
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 from libs import db, github
 from libs.settings import load_settings
 
@@ -28,7 +33,7 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    settings = load_settings(Path(__file__).resolve().parent)
+    settings = load_settings(PROJECT_ROOT)
     wanted = max(1, args.count if args.count is not None else settings["fetch_count"])
 
     conn = db.connect(settings["db_path"])

--- a/scripts/star.py
+++ b/scripts/star.py
@@ -8,6 +8,11 @@ import logging
 import sys
 from pathlib import Path
 
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 from libs import db, github
 from libs.settings import load_settings
 
@@ -32,7 +37,7 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    settings = load_settings(Path(__file__).resolve().parent)
+    settings = load_settings(PROJECT_ROOT)
     min_score = args.min_score if args.min_score is not None else settings["star_threshold"]
     window_hours = args.window_hours if args.window_hours is not None else settings["window_hours"]
     dry_run = args.dry_run or settings["dry_run"]

--- a/scripts/subscribe.py
+++ b/scripts/subscribe.py
@@ -8,6 +8,11 @@ import logging
 import sys
 from pathlib import Path
 
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 from libs import db, github
 from libs.settings import load_settings
 
@@ -32,7 +37,7 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    settings = load_settings(Path(__file__).resolve().parent)
+    settings = load_settings(PROJECT_ROOT)
     min_score = args.min_score if args.min_score is not None else settings["subscribe_threshold"]
     window_hours = args.window_hours if args.window_hours is not None else settings["window_hours"]
     dry_run = args.dry_run or settings["dry_run"]


### PR DESCRIPTION
## Summary

- Move the four step CLIs into `scripts/`: `scripts/{fetch,evaluate,subscribe,star}.py`.
- Rename `scheduler.py` → `main.py` at the project root.
- Add `scripts/__init__.py` so `main.py` can do `from scripts.fetch import main as fetch_main`.
- Each script in `scripts/` now sets `PROJECT_ROOT = Path(__file__).resolve().parent.parent` and prepends it to `sys.path`, so they still work when invoked directly (`python3 scripts/fetch.py -n 5`).
- README usage examples updated to the new paths.

## Test plan

- [x] `python3 scripts/fetch.py --help` works
- [x] `python3 scripts/evaluate.py --help` works
- [x] `python3 scripts/subscribe.py --help` works
- [x] `python3 scripts/star.py --help` works
- [x] `python3 main.py --help` works
- [x] `from scripts import fetch, evaluate, subscribe, star` imports cleanly
- [ ] `python3 main.py --dry-run` end-to-end (requires `GITHUB_TOKEN` + Ollama)